### PR TITLE
fixes `vite-plugin-pwa` base path issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,11 +8,12 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      base: '/routine',
+      includeAssets: ['favicon.ico', 'favicon/apple-touch-icon.png'],
       manifest: {
         name: 'Morning Routine Helper',
         short_name: 'Routine',
         description: 'A simple tool to help keep your mornings on track.',
+        start_url: '/routine',
         theme_color: '#ffffff',
         icons: [
           {


### PR DESCRIPTION
- changed config to use the `start_url` parameter, ensuring the app will bookmark on the correct page
- initial config set the `base` to '/routine', leading to a correct initial path, but improperly named manifest and service worker files. It worked in dev mode, but didn't build correctly.

meta: this is a good reminder to test the built version before merging (instead of just testing on the dev server)